### PR TITLE
Version 3.5.10 (Dependency Updates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.10] - 2024-03-06
+
+### Changed in 3.5.10
+
+- Updated dependencies:
+  - Updated `senzing-commons` to version `3.2.0` from version `3.1.4` 
+  - Updated Jetty dependencies to version `9.4.54.v20240208`
+    from version `9.4.53.v20231009` 
+  - Updated Jackson dependencies to version `2.16.1` from version `2.15.3`
+  - Updated `junit-jupiter` to version `5.10.2` from version `5.10.1`
+  - Updated `icu4j` to version `74.2` from version `74.1`
+  - qUpdated `sqs` to version `2.24.12` from version `2.21.40`
+  - Updated `kafka-clients` to version `3.7.0` from version `3.6.1`
+  - Updated SLF4J dependencies to version `2.0.12` from version `2.0.9`
+  - Updated `org.glassfish/javax.annotation` to `jakarta.annotation-api` version `2.1.1`
+  - Updated Spring dependencies to version `5.3.32` from version `5.3.30`
+  - Updated `swagger-annotations` to version `2.2.20` from version `2.2.18`
+  - Updated `swagger-codegen-maven-plugin` to version `3.0.54` from version `3.0.20`
+  - Updated `build-helper-manve-plugin` to version `3.5.0` from version `3.4.0`
+  - Updated `maven-surefire-plugin` to version `3.2.5` from version `3.1.2`
+  - Updated `maven-compiler-plugin` to version `3.12.1` from version `3.11.0`
+  - Updated `maven-shade-plugin` to version `3.5.2` from version `3.5.1`
+
 ## [3.5.9] - 2023-12-08
 
 ### Changed in 3.5.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated `org.glassfish/javax.annotation` to `jakarta.annotation-api` version `2.1.1`
   - Updated Spring dependencies to version `5.3.32` from version `5.3.30`
   - Updated `swagger-annotations` to version `2.2.20` from version `2.2.18`
-  - Updated `swagger-codegen-maven-plugin` to version `3.0.54` from version `3.0.20`
   - Updated `build-helper-manve-plugin` to version `3.5.0` from version `3.4.0`
   - Updated `maven-surefire-plugin` to version `3.2.5` from version `3.1.2`
   - Updated `maven-compiler-plugin` to version `3.12.1` from version `3.11.0`

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV REFRESHED_AT=2023-11-14
 
 LABEL Name="senzing/senzing-api-server-builder" \
       Maintainer="support@senzing.com" \
-      Version="3.5.8"
+      Version="3.5.10"
 
 # Set environment variables.
 
@@ -40,7 +40,7 @@ ENV REFRESHED_AT=2023-11-14
 
 LABEL Name="senzing/senzing-api-server" \
       Maintainer="support@senzing.com" \
-      Version="3.5.8"
+      Version="3.5.10"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.5.9</version>
+  <version>3.5.10</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.1.4, 3.99999.99999)</version>
+      <version>[3.2.0, 3.99999.99999)</version>
     </dependency>
     <dependency>
      <groupId>org.xerial</groupId>
@@ -26,53 +26,53 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.53.v20231009</version>
+      <version>9.4.54.v20240208</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.53.v20231009</version>
+      <version>9.4.54.v20240208</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-servlets -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlets</artifactId>
-      <version>9.4.53.v20231009</version>
+      <version>9.4.54.v20240208</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-rewrite</artifactId>
-      <version>9.4.53.v20231009</version>
+      <version>9.4.54.v20240208</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-proxy</artifactId>
-      <version>9.4.53.v20231009</version>
+      <version>9.4.54.v20240208</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-server</artifactId>
-      <version>9.4.53.v20231009</version>
+      <version>9.4.54.v20240208</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-common</artifactId>
-      <version>9.4.53.v20231009</version>
+      <version>9.4.54.v20240208</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-servlet</artifactId>
-      <version>9.4.53.v20231009</version>
+      <version>9.4.54.v20240208</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>javax-websocket-server-impl</artifactId>
-      <version>9.4.53.v20231009</version>
+      <version>9.4.54.v20240208</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-api</artifactId>
-      <version>9.4.53.v20231009</version>
+      <version>9.4.54.v20240208</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
@@ -123,27 +123,27 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.15.3</version>
+      <version>2.16.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.15.3</version>
+      <version>2.16.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.15.3</version>
+      <version>2.16.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.15.3</version>
+      <version>2.16.1</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.10.1</version>
+      <version>5.10.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -164,7 +164,7 @@
     <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>
-      <version>74.1</version>
+      <version>74.2</version>
     </dependency>
     <dependency>
       <groupId>org.ini4j</groupId>
@@ -174,7 +174,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.21.40</version>
+      <version>2.24.12</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
@@ -184,22 +184,22 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>3.6.1</version>
+      <version>3.7.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <version>2.15.3</version>
+      <version>2.16.1</version>
     </dependency>
     <dependency>
        <groupId>org.slf4j</groupId>
        <artifactId>slf4j-api</artifactId>
-       <version>2.0.9</version>
+       <version>2.0.12</version>
    </dependency>
    <dependency>
        <groupId>org.slf4j</groupId>
        <artifactId>slf4j-simple</artifactId>
-       <version>2.0.9</version>
+       <version>2.0.12</version>
    </dependency>
 
     <!-- add dependencies that were present in JDK 8, but optional in JDK 11 -->
@@ -226,33 +226,33 @@
 
     <!-- dependencies needed for generated java client tests -->
     <dependency>
-      <groupId>org.glassfish</groupId>
-      <artifactId>javax.annotation</artifactId>
-      <version>3.1.1</version>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>2.1.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
-      <version>[5.3.30,5.9999.9999)</version>
+      <version>[5.3.32,5.9999.9999)</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>[5.3.30,5.9999.9999)</version>
+      <version>[5.3.32,5.9999.9999)</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>[5.3.30,5.9999.9999)</version>
+      <version>[5.3.32,5.9999.9999)</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-annotations</artifactId>
-      <version>2.2.18</version>
+      <version>2.2.20</version>
       <scope>test</scope>
     </dependency>
 </dependencies>
@@ -269,7 +269,7 @@
       <plugin>
         <groupId>io.swagger.codegen.v3</groupId>
         <artifactId>swagger-codegen-maven-plugin</artifactId>
-        <version>3.0.20</version>
+        <version>3.0.54</version>
         <executions>
           <execution>
             <id>generate-openapi-spec</id>
@@ -308,7 +308,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <phase>generate-test-sources</phase>
@@ -362,7 +362,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.2.5</version>
         <configuration>
           <jvm>${project.build.directory}/java-wrapper/bin/java-wrapper.bat</jvm>
           <systemPropertyVariables>
@@ -382,7 +382,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
+        <version>3.12.1</version>
         <configuration>
           <compilerArgs>
             <arg>-Xlint:unchecked</arg>
@@ -421,7 +421,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.2</version>
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
           <filters>

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
       <plugin>
         <groupId>io.swagger.codegen.v3</groupId>
         <artifactId>swagger-codegen-maven-plugin</artifactId>
-        <version>3.0.54</version>
+        <version>3.0.20</version>
         <executions>
           <execution>
             <id>generate-openapi-spec</id>


### PR DESCRIPTION
- Updated dependencies:
  - Updated `senzing-commons` to version `3.2.0` from version `3.1.4` 
  - Updated Jetty dependencies to version `9.4.54.v20240208`
    from version `9.4.53.v20231009` 
  - Updated Jackson dependencies to version `2.16.1` from version `2.15.3`
  - Updated `junit-jupiter` to version `5.10.2` from version `5.10.1`
  - Updated `icu4j` to version `74.2` from version `74.1`
  - qUpdated `sqs` to version `2.24.12` from version `2.21.40`
  - Updated `kafka-clients` to version `3.7.0` from version `3.6.1`
  - Updated SLF4J dependencies to version `2.0.12` from version `2.0.9`
  - Updated `org.glassfish/javax.annotation` to `jakarta.annotation-api` version `2.1.1`
  - Updated Spring dependencies to version `5.3.32` from version `5.3.30`
  - Updated `swagger-annotations` to version `2.2.20` from version `2.2.18`
  - Updated `build-helper-manve-plugin` to version `3.5.0` from version `3.4.0`
  - Updated `maven-surefire-plugin` to version `3.2.5` from version `3.1.2`
  - Updated `maven-compiler-plugin` to version `3.12.1` from version `3.11.0`
  - Updated `maven-shade-plugin` to version `3.5.2` from version `3.5.1`