### PR TITLE
Updated dependencies for version 3.5.14 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /bin/
+target/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated Amazon `sqs` from version `2.26.4` to `2.26.27`
   - Updated `kafka-clients` dependencies from version `3.7.0` to `3.8.0`
   - Updated `junit-jupiter` from version `5.10.2` to `5.10.3`
-  - Updated `maven-surefire-plugin` from version `3.3.1` to `3.6.0`
 
 ## [3.5.13] - 2024-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.14] - 2024-08-02
+
+### Changed in 3.5.14
+
+- Updated dependencies:
+  - Updated `jetty-xxxx` dependencies from version `9.4.54.v20240208` to `9.4.55.v20240627`
+  - Updated `jersey-xxxx` dependencies from version `2.43` to `2.44`
+  - Updated `jackson-xxxx` dependencies from version `2.17.1` to `2.17.2`
+  - Updated Amazon `sqs` from version `2.26.4` to `2.26.27`
+  - Updated `kafka-clients` dependencies from version `3.7.0` to `3.8.0`
+  - Updated `junit-jupiter` from version `5.10.2` to `5.10.3`
+  - Updated `maven-surefire-plugin` from version `3.3.1` to `3.6.0`
+
 ## [3.5.13] - 2024-06-24
 
 ### Changed in 3.5.13

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENV REFRESHED_AT=2024-06-24
 
 LABEL Name="senzing/senzing-api-server" \
   Maintainer="support@senzing.com" \
-  Version="3.5.13"
+  Version="3.5.14"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.5.12</version>
+  <version>3.5.14</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
@@ -26,78 +26,78 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.54.v20240208</version>
+      <version>9.4.55.v20240627</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.54.v20240208</version>
+      <version>9.4.55.v20240627</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-servlets -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlets</artifactId>
-      <version>9.4.54.v20240208</version>
+      <version>9.4.55.v20240627</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-rewrite</artifactId>
-      <version>9.4.54.v20240208</version>
+      <version>9.4.55.v20240627</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-proxy</artifactId>
-      <version>9.4.54.v20240208</version>
+      <version>9.4.55.v20240627</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-server</artifactId>
-      <version>9.4.54.v20240208</version>
+      <version>9.4.55.v20240627</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-common</artifactId>
-      <version>9.4.54.v20240208</version>
+      <version>9.4.55.v20240627</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-servlet</artifactId>
-      <version>9.4.54.v20240208</version>
+      <version>9.4.55.v20240627</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>javax-websocket-server-impl</artifactId>
-      <version>9.4.54.v20240208</version>
+      <version>9.4.55.v20240627</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-api</artifactId>
-      <version>9.4.54.v20240208</version>
+      <version>9.4.55.v20240627</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>2.43</version>
+      <version>2.44</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet</artifactId>
-      <version>2.43</version>
+      <version>2.44</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-sse</artifactId>
-      <version>2.43</version>
+      <version>2.44</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet-core</artifactId>
-      <version>2.43</version>
+      <version>2.44</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-jetty-http</artifactId>
-      <version>2.43</version>
+      <version>2.44</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
@@ -108,42 +108,42 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>2.43</version>
+      <version>2.44</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
-      <version>2.43</version>
+      <version>2.44</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
-      <version>2.43</version>
+      <version>2.44</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.17.1</version>
+      <version>2.17.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.17.1</version>
+      <version>2.17.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.17.1</version>
+      <version>2.17.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.17.1</version>
+      <version>2.17.2</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.10.2</version>
+      <version>5.10.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -174,7 +174,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.26.4</version>
+      <version>2.26.27</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
@@ -184,12 +184,12 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>3.7.0</version>
+      <version>3.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <version>2.17.1</version>
+      <version>2.17.2</version>
     </dependency>
     <dependency>
        <groupId>org.slf4j</groupId>
@@ -308,7 +308,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <phase>generate-test-sources</phase>
@@ -362,7 +362,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.6.0</version>
         <configuration>
           <jvm>${project.build.directory}/java-wrapper/bin/java-wrapper.bat</jvm>
           <systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -362,7 +362,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.3.1</version>
         <configuration>
           <jvm>${project.build.directory}/java-wrapper/bin/java-wrapper.bat</jvm>
           <systemPropertyVariables>


### PR DESCRIPTION
  - Updated `jetty-xxxx` dependencies from version `9.4.54.v20240208` to `9.4.55.v20240627`
  - Updated `jersey-xxxx` dependencies from version `2.43` to `2.44`
  - Updated `jackson-xxxx` dependencies from version `2.17.1` to `2.17.2`
  - Updated Amazon `sqs` from version `2.26.4` to `2.26.27`
  - Updated `kafka-clients` dependencies from version `3.7.0` to `3.8.0`
  - Updated `junit-jupiter` from version `5.10.2` to `5.10.3`
