### PR TITLE
Modified how ReplayNativeApiProvider constructs initialization exception to not mask underlying cause.

### DIFF
--- a/src/test/java/com/senzing/nativeapi/replay/ReplayNativeApiProvider.java
+++ b/src/test/java/com/senzing/nativeapi/replay/ReplayNativeApiProvider.java
@@ -304,9 +304,7 @@ public class ReplayNativeApiProvider implements NativeApiProvider {
       // to use for a "replay" test run THEN we have to fail with an error
       if (installed || direct || record || EXISTING_CACHE_DIRS.isEmpty()) {
         e.printStackTrace();
-        throw new ExceptionInInitializerError(
-            "Failed to find valid Senzing installation for integration test "
-            + "run.");
+        throw new ExceptionInInitializerError(e);
       }
 
     } catch (Error e) {


### PR DESCRIPTION
Modified how ReplayNativeApiProvider constructs initialization exception to not mask underlying cause.