### PR TITLE
Version 3.5.15 with Dependency Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.15] - 2024-10-08
+
+### Changed in 3.5.15
+
+- Updated dependencies:
+  - Updated `senzing-commons-java` dependencies from version `3.3.0` to `3.3.1`
+  - Updated `jetty-xxxx` dependencies from version `9.4.55.v20240627` to `9.4.56.v20240826`
+  - Updated `jersey-xxxx` dependencies from version `2.44` to `2.45`
+  - Updated `jackson-xxxx` dependencies from version `2.17.2` to `2.18.0`
+  - Updated `commons-csv` dependencies from version `1.11.0` to `1.12.0`
+  - Updated Amazon `sqs` from version `2.26.27` to `2.28.17`
+  - Updated `amqp-client` dependencies from version `5.21.0` to `5.22.0`
+  - Updated `slf4j-xxxxx` dependencies from version `2.0.13` to `2.0.16`
+  - Updated `junit-jupiter` from version `5.10.3` to `5.11.2`
+
 ## [3.5.14] - 2024-08-02
 
 ### Changed in 3.5.14

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENV REFRESHED_AT=2024-06-24
 
 LABEL Name="senzing/senzing-api-server" \
   Maintainer="support@senzing.com" \
-  Version="3.5.14"
+  Version="3.5.15"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.5.14</version>
+  <version>3.5.15</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.3.0, 3.99999.99999)</version>
+      <version>[3.3.1, 3.99999.99999)</version>
     </dependency>
     <dependency>
      <groupId>org.xerial</groupId>
@@ -26,78 +26,78 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.55.v20240627</version>
+      <version>9.4.56.v20240826</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.55.v20240627</version>
+      <version>9.4.56.v20240826</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-servlets -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlets</artifactId>
-      <version>9.4.55.v20240627</version>
+      <version>9.4.56.v20240826</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-rewrite</artifactId>
-      <version>9.4.55.v20240627</version>
+      <version>9.4.56.v20240826</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-proxy</artifactId>
-      <version>9.4.55.v20240627</version>
+      <version>9.4.56.v20240826</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-server</artifactId>
-      <version>9.4.55.v20240627</version>
+      <version>9.4.56.v20240826</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-common</artifactId>
-      <version>9.4.55.v20240627</version>
+      <version>9.4.56.v20240826</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-servlet</artifactId>
-      <version>9.4.55.v20240627</version>
+      <version>9.4.56.v20240826</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>javax-websocket-server-impl</artifactId>
-      <version>9.4.55.v20240627</version>
+      <version>9.4.56.v20240826</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-api</artifactId>
-      <version>9.4.55.v20240627</version>
+      <version>9.4.56.v20240826</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>2.44</version>
+      <version>2.45</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet</artifactId>
-      <version>2.44</version>
+      <version>2.45</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-sse</artifactId>
-      <version>2.44</version>
+      <version>2.45</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet-core</artifactId>
-      <version>2.44</version>
+      <version>2.45</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-jetty-http</artifactId>
-      <version>2.44</version>
+      <version>2.45</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
@@ -108,48 +108,48 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>2.44</version>
+      <version>2.45</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
-      <version>2.44</version>
+      <version>2.45</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
-      <version>2.44</version>
+      <version>2.45</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.17.2</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.17.2</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.17.2</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.17.2</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.10.3</version>
+      <version>5.11.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
-      <version>1.11.0</version>
+      <version>1.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
@@ -174,12 +174,12 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.26.27</version>
+      <version>2.28.17</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>5.21.0</version>
+      <version>5.22.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
@@ -189,12 +189,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <version>2.17.2</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
        <groupId>org.slf4j</groupId>
        <artifactId>slf4j-api</artifactId>
-       <version>2.0.13</version>
+       <version>2.0.16</version>
    </dependency>
    <dependency>
        <groupId>org.slf4j</groupId>


### PR DESCRIPTION
- Updated dependencies:
  - Updated `senzing-commons-java` dependencies from version `3.3.0` to `3.3.1`
  - Updated `jetty-xxxx` dependencies from version `9.4.55.v20240627` to `9.4.56.v20240826`
  - Updated `jersey-xxxx` dependencies from version `2.44` to `2.45`
  - Updated `jackson-xxxx` dependencies from version `2.17.2` to `2.18.0`
  - Updated `commons-csv` dependencies from version `1.11.0` to `1.12.0`
  - Updated Amazon `sqs` from version `2.26.27` to `2.28.17`
  - Updated `amqp-client` dependencies from version `5.21.0` to `5.22.0`
  - Updated `slf4j-xxxxx` dependencies from version `2.0.13` to `2.0.16`
  - Updated `junit-jupiter` from version `5.10.3` to `5.11.2`