### PR TITLE
Updated dependencies for version 3.5.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.18] - 2025-06-09
+
+### Changed in 3.5.18
+
+- Updated dependencies:
+  - Updated `senzing-commons-java` dependencies from version `3.3.3` to `3.3.4`
+  - Updated `jersey-xxxx` dependencies from version `2.46` to `2.47`
+  - Updated `jackson-xxxx` dependencies from version `2.18.3` to `2.19.0`
+  - Updated `junit-jupiter` from version `5.12.2` to `5.13.1`
+  - Updated Amazon `sqs` from version `2.31.22` to `2.31.59`
+  - Updated `kafka-clients` dependencies from version `3.9.0` to `3.9.1`
+  - Updated `build-helper-maven-plugin` from version `3.6.0` to `3.6.1`
+
 ## [3.5.17] - 2025-04-16
 
 ### Changed in 3.5.17

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENV REFRESHED_AT=2024-06-24
 
 LABEL Name="senzing/senzing-api-server" \
   Maintainer="support@senzing.com" \
-  Version="3.5.17"
+  Version="3.5.18"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.5.17</version>
+  <version>3.5.18</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.3.3, 3.99999.99999)</version>
+      <version>[3.3.4, 3.99999.99999)</version>
     </dependency>
     <dependency>
      <groupId>org.xerial</groupId>
@@ -77,27 +77,27 @@
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>2.46</version>
+      <version>2.47</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet</artifactId>
-      <version>2.46</version>
+      <version>2.47</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-sse</artifactId>
-      <version>2.46</version>
+      <version>2.47</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet-core</artifactId>
-      <version>2.46</version>
+      <version>2.47</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-jetty-http</artifactId>
-      <version>2.46</version>
+      <version>2.47</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
@@ -108,42 +108,42 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>2.46</version>
+      <version>2.47</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
-      <version>2.46</version>
+      <version>2.47</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
-      <version>2.46</version>
+      <version>2.47</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.18.3</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.18.3</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.18.3</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.18.3</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.12.2</version>
+      <version>5.13.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -174,7 +174,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.31.22</version>
+      <version>2.31.59</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
@@ -184,12 +184,12 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>3.9.0</version>
+      <version>3.9.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <version>2.18.3</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
        <groupId>org.slf4j</groupId>
@@ -308,7 +308,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <phase>generate-test-sources</phase>


### PR DESCRIPTION
  - Updated `senzing-commons-java` dependencies from version `3.3.3` to `3.3.4`
  - Updated `jersey-xxxx` dependencies from version `2.46` to `2.47`
  - Updated `jackson-xxxx` dependencies from version `2.18.3` to `2.19.0`
  - Updated `junit-jupiter` from version `5.12.2` to `5.13.1`
  - Updated Amazon `sqs` from version `2.31.22` to `2.31.59`
  - Updated `kafka-clients` dependencies from version `3.9.0` to `3.9.1`
  - Updated `build-helper-maven-plugin` from version `3.6.0` to `3.6.1`